### PR TITLE
Added package json and fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "version": "1.0.1",
   "name": "cordova-plugin-stone",
-  "cordova_name": "Cordova Stone",
-  "description": "Copied by Igor Trindade from Stone",
+  "cordova_name": "Cordova Stone Plugin",
+  "description": "Forked by Igor Trindade from Stone to add missing package.json",
   "license": "MIT",
   "repo": "",
   "issue": "",
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/igortrinidad/plugin-cordova"
+    "url": "https://github.com/igortrinidad/plugin-cordova-stone"
   },
   "keywords": [
     "ecosystem:cordova",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.1",
-  "name": "cordova-plugin-stone",
+  "name": "cordova-plugin-stone-sdk",
   "cordova_name": "Cordova Stone Plugin",
   "description": "Forked by Igor Trindade from Stone to add missing package.json",
   "license": "MIT",
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/igortrinidad/plugin-cordova-stone"
+    "url": "https://github.com/igortrinidad/cordova-plugin-stone-sdk.git"
   },
   "keywords": [
     "ecosystem:cordova",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "version": "1.0.1",
+  "name": "cordova-plugin-stone",
+  "cordova_name": "Cordova Stone",
+  "description": "Copied by Igor Trindade from Stone",
+  "license": "MIT",
+  "repo": "",
+  "issue": "",
+  "author": {
+    "name": "Igor Trindade",
+    "email": "igorlucast@hotmail.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/igortrinidad/plugin-cordova"
+  },
+  "keywords": [
+    "ecosystem:cordova",
+    "cordova-android",
+    "cordova-ios",
+    "ios",
+    "android",
+    "cordova"
+  ],
+  "platforms": [
+    "android",
+    "ios"
+  ],
+  "engines": [],
+  "englishdoc": ""
+}

--- a/plugin.xml
+++ b/plugin.xml
@@ -32,7 +32,7 @@
         </config-file>
 
         <source-file src="src/android/StoneSDK.java" target-dir="src/br/com/stone/cordova/sdk/" />
-        <source-file src="src/android/libs/stone-sdk-2.5.2.aar" target-dir="libs" />
+        <source-file src="src/android/libs/stone-sdk-2.5.3.aar" target-dir="libs" />
 
     </platform>
 


### PR DESCRIPTION
Olá pessoal,

Estou começando a desenvolver um app que vai utilizar o plugin-cordova(Stone) com pinpad e estava dando erro na instalação pela falta do arquivo package.json, criei um bem simples somente para conseguir instalar sem precisar copiar na mão os arquivos e também encontrei um errono plugin.xml que direcionava para a sdk 2.5.2, porém a disponibilizada no plugin era a 2.5.3, aproveitei e corrigi também.

Este pull é somente com estes fixes, fiquem à vontade para alterar o package com as infos de vocês.

Valeu pessoal!